### PR TITLE
fix: #18320 fixing text in dark mode modals have the wrong shade

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/theme/InvalidThemeModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/InvalidThemeModal.tsx
@@ -3,7 +3,7 @@ import Heading from '../../../../admin-x-ds/global/Heading';
 import List from '../../../../admin-x-ds/global/List';
 import ListItem from '../../../../admin-x-ds/global/ListItem';
 import NiceModal from '@ebay/nice-modal-react';
-import React, {ReactNode, useState} from 'react';
+import React, {ReactNode, useState, useEffect} from 'react';
 import {ConfirmationModalContent} from '../../../../admin-x-ds/global/modal/ConfirmationModal';
 import {ThemeProblem} from '../../../../api/themes';
 
@@ -17,10 +17,31 @@ type FatalError = {
 
 export const ThemeProblemView = ({problem}:{problem: ThemeProblem}) => {
     const [isExpanded, setExpanded] = useState(false);
-
+    const [isDarkMode, setIsDarkMode] = useState(false);
     const handleClick = () => {
         setExpanded(!isExpanded);
     };
+
+    useEffect(() => {
+        // Set up a listener for changes in the color scheme
+        const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+        
+        // Initial setup
+        setIsDarkMode(darkModeMediaQuery.matches);
+
+        // Handle color scheme changes
+        const handleColorSchemeChange = (event: MediaQueryListEvent) => {
+            setIsDarkMode(event.matches);
+        };
+
+        darkModeMediaQuery.addListener(handleColorSchemeChange);
+
+        // Clean up the listener when the component is unmounted
+        return () => {
+            darkModeMediaQuery.removeListener(handleColorSchemeChange);
+        };
+    }, []); 
+
 
     return <ListItem
         title={
@@ -42,7 +63,7 @@ export const ThemeProblemView = ({problem}:{problem: ThemeProblem}) => {
                         <div className='mt-2 px-4 text-[13px] leading-8'>
                             <div dangerouslySetInnerHTML={{__html: problem.details}} className='mb-4' />
                             <Heading level={6}>Affected files:</Heading>
-                            <ul className='mt-1'>
+                            <ul className={`mt-1 ${isDarkMode? 'text-white' : ''}`}>
                                 {problem.failures.map(failure => <li><code>{failure.ref}</code>{failure.message ? `: ${failure.message}` : ''}</li>)}
                             </ul>
                         </div> :

--- a/apps/admin-x-settings/src/components/settings/site/theme/ThemeInstalledModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/ThemeInstalledModal.tsx
@@ -3,7 +3,7 @@ import Heading from '../../../../admin-x-ds/global/Heading';
 import List from '../../../../admin-x-ds/global/List';
 import ListItem from '../../../../admin-x-ds/global/ListItem';
 import NiceModal from '@ebay/nice-modal-react';
-import React, {ReactNode, useState} from 'react';
+import React, {ReactNode, useState, useEffect} from 'react';
 import useHandleError from '../../../../utils/api/handleError';
 import {ConfirmationModalContent} from '../../../../admin-x-ds/global/modal/ConfirmationModal';
 import {InstalledTheme, ThemeProblem, useActivateTheme} from '../../../../api/themes';
@@ -12,6 +12,9 @@ import {showToast} from '../../../../admin-x-ds/global/Toast';
 export const ThemeProblemView = ({problem}:{problem: ThemeProblem}) => {
     const [isExpanded, setExpanded] = useState(false);
 
+
+
+    
     return <ListItem
         title={
             <>
@@ -48,10 +51,33 @@ const ThemeInstalledModal: React.FC<{
 }> = ({title, prompt, installedTheme, onActivate}) => {
     const {mutateAsync: activateTheme} = useActivateTheme();
     const handleError = useHandleError();
+    const [isDarkMode, setIsDarkMode] = useState(false);
 
+    useEffect(() => {
+        // Set up a listener for changes in the color scheme
+        const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+        
+        // Initial setup
+        setIsDarkMode(darkModeMediaQuery.matches);
+
+        // Handle color scheme changes
+        const handleColorSchemeChange = (event: MediaQueryListEvent) => {
+            setIsDarkMode(event.matches);
+        };
+
+        darkModeMediaQuery.addListener(handleColorSchemeChange);
+
+        // Clean up the listener when the component is unmounted
+        return () => {
+            darkModeMediaQuery.removeListener(handleColorSchemeChange);
+        };
+    }, []); 
+
+
+    
     let errorPrompt = null;
     if (installedTheme.gscan_errors) {
-        errorPrompt = <div className="mt-6">
+        errorPrompt = <div className={`mt-6 ${isDarkMode? 'text-white' : ''}`}>
             <List hint={<>Highly recommended to fix, functionality <strong>could</strong> be restricted</>} title="Errors">
                 {installedTheme.gscan_errors?.map(error => <ThemeProblemView problem={error} />)}
             </List>

--- a/ghost/admin/app/components/editor/modals/delete-snippet.hbs
+++ b/ghost/admin/app/components/editor/modals/delete-snippet.hbs
@@ -1,10 +1,18 @@
+<style>
+  @media (prefers-color-scheme: dark) {
+    /* Dark mode styles */
+    .set-color-white {
+      color: #ffffff;
+    }
+  }
+</style>
 <div class="modal-content" data-test-modal="delete-snippet">
     <header class="modal-header">
         <h1>Confirm snippet deletion</h1>
     </header>
     <button type="button" class="close" title="Close" {{on "click" @close}}>{{svg-jar "close"}}<span class="hidden">Close</span></button>
 
-    <div class="modal-body">
+    <div class="modal-body set-color-white">
         <p>
             You're about to delete the "<strong>{{@data.snippet.name}}</strong>" snippet. This is permanent, and will delete the snippet for all staff users. It will <strong>not</strong> change any posts where you’ve used this snippet in the past.
         </p>

--- a/ghost/admin/app/components/editor/modals/update-snippet.hbs
+++ b/ghost/admin/app/components/editor/modals/update-snippet.hbs
@@ -1,10 +1,19 @@
+
+<style>
+  @media (prefers-color-scheme: dark) {
+    /* Dark mode styles */
+    .set-color-white {
+      color: #ffffff;
+    }
+  }
+</style>
 <div class="modal-content" data-test-modal="update-snippet">
     <header class="modal-header">
         <h1>Update this snippet?</h1>
     </header>
     <button type="button" class="close" title="Close" {{on "click" @close}}>{{svg-jar "close"}}<span class="hidden">Close</span></button>
 
-    <div class="modal-body">
+    <div class="modal-body set-color-white">
         <p>
             "<strong>{{@data.snippet.name}}</strong>" will be overwritten.
             Don't worry, this will only affect using the snippet in the future.

--- a/ghost/admin/app/components/modals/delete-post.hbs
+++ b/ghost/admin/app/components/modals/delete-post.hbs
@@ -1,10 +1,19 @@
+
+<style>
+  @media (prefers-color-scheme: dark) {
+    /* Dark mode styles */
+    .set-color-white {
+      color: #ffffff;
+    }
+  }
+</style>
 <div class="modal-content" {{on-key "Enter" (perform this.deletePostTask)}}>
     <header class="modal-header">
         <h1>Are you sure you want to delete this {{@data.post.displayName}}?</h1>
     </header>
     <button type="button" class="close" title="Close" {{on "click" @close}}>{{svg-jar "close"}}<span class="hidden">Close</span></button>
 
-    <div class="modal-body">
+    <div class="modal-body set-color-white">
         <p>
             You're about to delete "<strong>{{@data.post.title}}</strong>".
             This is permanent! We warned you, k?

--- a/ghost/admin/app/components/modals/design/install-theme.hbs
+++ b/ghost/admin/app/components/modals/design/install-theme.hbs
@@ -1,3 +1,11 @@
+<style>
+  @media (prefers-color-scheme: dark) {
+    /* Dark mode styles */
+    .set-color-white {
+      color: #ffffff;
+    }
+  }
+</style>
 <div class="modal-content" data-test-modal="install-theme">
     <div class="theme-validation-container">
         <header class="modal-header">
@@ -58,7 +66,7 @@
             {{#if this.validationErrors}}
                 <div>
                     <h2 class="mb0 mt4 f5 fw6">Errors</h2>
-                    <p class="mb2">Highly recommended to fix, functionality <strong>could</strong> be restricted</p>
+                    <p class="mb2 set-color-white">Highly recommended to fix, functionality <strong>could</strong> be restricted</p>
                 </div>
                 <ul class="pa0">
                 {{#each this.validationErrors as |error|}}

--- a/ghost/admin/app/components/modals/design/theme-errors.hbs
+++ b/ghost/admin/app/components/modals/design/theme-errors.hbs
@@ -1,3 +1,11 @@
+<style>
+  @media (prefers-color-scheme: dark) {
+    /* Dark mode styles */
+    .set-color-white {
+      color: #ffffff;
+    }
+  }
+</style>
 <div class="modal-content">
     <div class="theme-validation-container" data-test-modal="theme-errors">
         <header class="modal-header">
@@ -29,7 +37,7 @@
             {{#if @data.errors}}
                 <div>
                     <h2 class="mb0 mt4 f5 fw6">Errors</h2>
-                    <p class="mb2">Highly recommended to fix, functionality <span>could</span> be restricted</p>
+                    <p class="mb2 set-color-white ">Highly recommended to fix, functionality <span>could</span> be restricted</p>
                 </div>
 
                 <ul class="pa0" data-test-theme-errors>

--- a/ghost/admin/app/components/modals/design/upload-theme.hbs
+++ b/ghost/admin/app/components/modals/design/upload-theme.hbs
@@ -1,3 +1,11 @@
+<style>
+  @media (prefers-color-scheme: dark) {
+    /* Dark mode styles */
+    .set-color-white {
+      color: #ffffff;
+    }
+  }
+</style>
 <div class="modal-content" data-test-modal="upload-theme">
     <div class="theme-validation-container">
         <header class="modal-header">
@@ -20,7 +28,7 @@
         <div class="modal-body">
             {{#if this.theme}}
                 {{#if this.hasWarningsOrErrors}}
-                    <p data-test-state="installed-with-notes">
+                    <p data-test-state="installed-with-notes set-color-white">
                         The theme <strong>"{{this.themeName}}"</strong> was installed successfully but we detected some {{if this.validationErrors "errors" "warnings"}}.
                         {{#if this.canActivateTheme}}
                             You are still able to activate and use the theme but it is recommended to fix these {{if this.validationErrors "errors" "warnings"}} before you do so.
@@ -30,7 +38,7 @@
                     {{#if this.validationErrors}}
                         <div>
                             <h2 class="mb0 mt4 f5 fw6">Errors</h2>
-                            <p class="mb2">Highly recommended to fix, functionality <strong>could</strong> be restricted</p>
+                            <p class="mb2 set-color-white">Highly recommended to fix, functionality <strong>could</strong> be restricted</p>
                         </div>
                         <ul class="pa0">
                         {{#each this.validationErrors as |error|}}
@@ -87,7 +95,7 @@
                 {{#if this.validationErrors}}
                     <div>
                         <h2 class="mb0 mt4 f5 fw6">Errors</h2>
-                        <p class="mb2">Highly recommended to fix, functionality <strong>could</strong> be restricted</p>
+                        <p class="mb2 set-color-white ">Highly recommended to fix, functionality <strong>could</strong> be restricted</p>
                     </div>
                     <ul class="pa0">
                     {{#each this.validationErrors as |error|}}


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

This commit addresses issue #18320 where the regular text was appearing dark on dark background when uploading a theme with errors in dark mode. The issue has been resolved to ensure proper text visibility. 

Changes made:
- Added conditional styling to ensure text is light on a dark background in dark mode.

Fixes: #18320 

Checklist:
- [x] There's a clear use-case for this code change, explained above
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)
We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
copilot:summary
